### PR TITLE
Specify type of MaxSize on RHS to fix golint warning caused by golang/lint#7.

### DIFF
--- a/glog_file.go
+++ b/glog_file.go
@@ -31,7 +31,7 @@ import (
 )
 
 // MaxSize is the maximum size of a log file in bytes.
-var MaxSize uint64 = 1024 * 1024 * 1800
+var MaxSize = uint64(1024 * 1024 * 1800)
 
 // logDirs lists the candidate directories for new log files.
 var logDirs []string


### PR DESCRIPTION
Before, I was getting this warning from golint:

```
glog_file.go:34: should omit type uint64 from declaration of var MaxSize; it will be inferred from the right-hand side
```
