### PR TITLE
If you log to standard error instead of to files consider -stderrThreshold flag

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -646,7 +646,9 @@ func (l *loggingT) output(s severity, buf *buffer) {
 	}
 	data := buf.Bytes()
 	if l.toStderr {
-		os.Stderr.Write(data)
+		if s >= l.stderrThreshold.get() {
+			os.Stderr.Write(data)
+		}
 	} else {
 		if l.alsoToStderr || s >= l.stderrThreshold.get() {
 			os.Stderr.Write(data)

--- a/glog_file.go
+++ b/glog_file.go
@@ -45,6 +45,7 @@ func createLogDirs() {
 		logDirs = append(logDirs, *logDir)
 	}
 	logDirs = append(logDirs, os.TempDir())
+	os.Stderr.WriteString(fmt.Sprintf("log dirs.: %v\n", logDirs))
 }
 
 var (


### PR DESCRIPTION
If you set up flag -logtostderr=true maybe it's not a bad idea to consider also value of -stderrthreshold flag and print out a log message only if log level for this message is greater or equal stderrThreshold.
