### PR TITLE
Add examples of flag use to README

### DIFF
--- a/README
+++ b/README
@@ -35,7 +35,8 @@ The comment from glog.go introduces the ideas:
 	
 		glog.V(2).Infoln("Processed", nItems, "elements")
 
-        In order for the glog-specific flags to take effect, package main should resemble:
+        In order for the glog-specific flags to take effect, 
+	package main should resemble:
 
                 package main
 

--- a/README
+++ b/README
@@ -35,6 +35,25 @@ The comment from glog.go introduces the ideas:
 	
 		glog.V(2).Infoln("Processed", nItems, "elements")
 
+        In order for the glog-specific flags to take effect, package main should resemble:
+
+                package main
+
+	    	import (
+	        	"flag"	
+			"github.com/golang/glog"
+        	)	
+
+        	func main() {
+	        	flag.Parse()
+			defer glog.Flush()  // optional
+			// continue your program
+        	}
+
+    	Then call the program with your desired command-line flags:
+
+        	go run main.go -log_dir="./log"
+        
 
 The repository contains an open source version of the log package
 used inside Google. The master copy of the source lives inside


### PR DESCRIPTION
It took me forever to figure out how to use the flag functionality; even in the generate godoc for glog, the instruction to call flag.Parse() is very easy to overlook. 

By putting the information in the pull request in the README it will help prevent confusion to people either new to golang or who lack knowledge of the flag package. 