### PR TITLE
Export glog bugfix.

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -676,7 +676,10 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 		}
 	}
 	data := buf.Bytes()
-	if l.toStderr {
+	if !flag.Parsed() {
+		os.Stderr.Write([]byte("ERROR: logging before flag.Parse: "))
+		os.Stderr.Write(data)
+	} else if l.toStderr {
 		os.Stderr.Write(data)
 	} else {
 		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {


### PR DESCRIPTION
@robpike This is an export of an internal bug fix. The original author is @Sajmani

Fix problem that -log_dir will not be respected when anything is logged before flag.Parse().

Before this change, premature logging resulted into log files being put in the default location (e.g. /tmp), but not the one specified by the log_dir flag.

After this change, premature logging will not result into the creation of the log files yet. Instead, the log message will be printed to stderr.