### PR TITLE
Initialize stderrThreshold before calling flag.Var

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -396,15 +396,15 @@ type flushSyncWriter interface {
 }
 
 func init() {
+	// Default stderrThreshold is ERROR.
+	logging.stderrThreshold = errorLog
+
 	flag.BoolVar(&logging.toStderr, "logtostderr", false, "log to standard error instead of files")
 	flag.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
 	flag.Var(&logging.verbosity, "v", "log level for V logs")
 	flag.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
 	flag.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
 	flag.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
-
-	// Default stderrThreshold is ERROR.
-	logging.stderrThreshold = errorLog
 
 	logging.setVState(0, nil, false)
 	go logging.flushDaemon()


### PR DESCRIPTION
This way, the default value is initialized correctly, i.e.
`fmt.Println(flag.Lookup("stderrthreshold").DefValue)`
prints 2 (for ERROR) instead of 0 (for INFO).