### PR TITLE
Add ANSI colored logging

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -550,56 +550,11 @@ func (l *loggingT) header(s severity, depth int) (*buffer, string, int) {
 
 // formatHeader formats a log header using the provided file name and line number.
 func (l *loggingT) formatHeader(s severity, file string, line int) *buffer {
-	if l.color {
-		return l.formatColorHeader(s, file, line)
-	}
-	now := timeNow()
-	if line < 0 {
-		line = 0 // not a real line number, but acceptable to someDigits
-	}
-	if s > fatalLog {
-		s = infoLog // for safety.
-	}
-	buf := l.getBuffer()
-
-	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
-	// It's worth about 3X. Fprintf is hard.
-	_, month, day := now.Date()
-	hour, minute, second := now.Clock()
-	// Lmmdd hh:mm:ss.uuuuuu threadid file:line]
-	buf.tmp[0] = severityChar[s]
-	buf.twoDigits(1, int(month))
-	buf.twoDigits(3, day)
-	buf.tmp[5] = ' '
-	buf.twoDigits(6, hour)
-	buf.tmp[8] = ':'
-	buf.twoDigits(9, minute)
-	buf.tmp[11] = ':'
-	buf.twoDigits(12, second)
-	buf.tmp[14] = '.'
-	buf.nDigits(6, 15, now.Nanosecond()/1000, '0')
-	buf.tmp[21] = ' '
-	buf.nDigits(7, 22, pid, ' ') // TODO: should be TID
-	buf.tmp[29] = ' '
-	buf.tmp[30] = '['
-	buf.Write(buf.tmp[:31])
-	buf.WriteString(file)
-	buf.tmp[0] = ':'
-	n := buf.someDigits(1, line)
-	buf.tmp[n+1] = ']'
-	buf.tmp[n+2] = ' '
-	buf.Write(buf.tmp[:n+3])
-	return buf
-}
-
-// formatHeader formats a log header using the provided file name and line number.
-// TODO: Could be combined with formatHeader and just add if statements for begin
-// and end escape sequences.
-func (l *loggingT) formatColorHeader(s severity, file string, line int) *buffer {
 	// info = green
 	// warn = yellow
 	// error / fatal = red
-	colorstrs := []string{"\033[32m", "\033[33m", "\033[31m", "\033[31m"}
+	ANSIcolors := []string{"\033[32m", "\033[33m", "\033[31m", "\033[31m"}
+	ANSIclear := "\033[0m"
 	now := timeNow()
 	if line < 0 {
 		line = 0 // not a real line number, but acceptable to someDigits
@@ -609,7 +564,9 @@ func (l *loggingT) formatColorHeader(s severity, file string, line int) *buffer 
 	}
 	buf := l.getBuffer()
 
-	buf.WriteString(colorstrs[s])
+	if l.color {
+		buf.WriteString(ANSIcolors[s])
+	}
 	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
 	// It's worth about 3X. Fprintf is hard.
 	_, month, day := now.Date()
@@ -638,7 +595,9 @@ func (l *loggingT) formatColorHeader(s severity, file string, line int) *buffer 
 	buf.tmp[n+1] = ']'
 	buf.tmp[n+2] = ' '
 	buf.Write(buf.tmp[:n+3])
-	buf.WriteString("\033[0m") // 'clear formatting' ANSI escape sequence
+	if l.color {
+		buf.WriteString(ANSIclear) // 'clear formatting' ANSI escape sequence
+	}
 	return buf
 }
 

--- a/glog_test.go
+++ b/glog_test.go
@@ -180,7 +180,7 @@ func TestHeader(t *testing.T) {
 	pid = 1234
 	Info("test")
 	var line int
-	format := "I0102 15:04:05.067890    1234 glog_test.go:%d] test\n"
+	format := "I0102 15:04:05.067890    1234 [glog_test.go:%d] test\n"
 	n, err := fmt.Sscanf(contents(infoLog), format, &line)
 	if n != 1 || err != nil {
 		t.Errorf("log format error: %d elements, error %s:\n%s", n, err, contents(infoLog))


### PR DESCRIPTION
I'm assuming that the 
```
+	// info = green
+	// warn = yellow
+	// error / fatal = red
```
is the correct color combination, but we could do something else.