### PR TITLE
Glogger type to allow adding prefixes to logs

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+github.com/golang/glog fork with added log namespacing per scope.
+
 glog
 ====
 
@@ -34,6 +36,23 @@ The comment from glog.go introduces the ideas:
 		}
 	
 		glog.V(2).Infoln("Processed", nItems, "elements")
+
+	Example of using Glogger to add a prefix to logs:
+
+		func (db *DB) GetBook(id string) (*Book, error) {
+			g := &glog.Glogger{Prefix: "GetBook() "}
+
+			book, err := db.GetBook(id); if err != nil {
+				// Assume the message returned in err is "database connection timed out"
+				g.Error(err.Error()) // logs "GetBook() database connection timed out"
+
+				return nil, errors.New("Some user friendly error")
+			}
+
+			// ...
+
+			return book, nil
+		}
 
 
 The repository contains an open source version of the log package

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-github.com/golang/glog fork with added log namespacing per scope.
-
 glog
 ====
 

--- a/README.md
+++ b/README.md
@@ -37,22 +37,23 @@ The comment from glog.go introduces the ideas:
 	
 		glog.V(2).Infoln("Processed", nItems, "elements")
 
-	Example of using Glogger to add a prefix to logs:
 
-		func (db *DB) GetBook(id string) (*Book, error) {
-			g := &glog.Glogger{Prefix: "GetBook() "}
+Example of using Glogger to add a prefix to logs:
 
-			book, err := db.GetBook(id); if err != nil {
-				// Assume the message returned in err is "database connection timed out"
-				g.Error(err.Error()) // logs "GetBook() database connection timed out"
+	func (db *DB) GetBook(id string) (*Book, error) {
+		g := &glog.Glogger{Prefix: "GetBook() "}
 
-				return nil, errors.New("Some user friendly error")
-			}
+		book, err := db.GetBook(id); if err != nil {
+			// Assume the message returned in err is "database connection timed out"
+			g.Error(err.Error()) // logs "GetBook() database connection timed out"
 
-			// ...
-
-			return book, nil
+			return nil, errors.New("Some user friendly error")
 		}
+
+		// ...
+
+		return book, nil
+	}
 
 
 The repository contains an open source version of the log package

--- a/glogger.go
+++ b/glogger.go
@@ -1,9 +1,7 @@
 // Glogger contains a copy of the exported glog logging functions but
 // it turns them into methods and allows adding prefixes to the logs.
-// This allows you "namespacing" the printout with something such as
-// the name of the function where that triggered it.
-
-// Eventually Glogger can be expanded to do more than simply add a prefix
+// This allows "namespacing" the printout with something such as
+// the name of the function that triggered it.
 
 package glog
 

--- a/glogger.go
+++ b/glogger.go
@@ -7,6 +7,10 @@
 
 package glog
 
+import (
+	"fmt"
+)
+
 // Glogger provides a prefix to log args
 type Glogger struct {
 	Prefix interface{}
@@ -14,6 +18,15 @@ type Glogger struct {
 
 func setPrefix(g *Glogger, args []interface{}) []interface{} {
 	return append([]interface{}{g.Prefix}, args...)
+}
+
+func setPrefixf(g *Glogger, format string) string {
+	pre, ok := g.Prefix.(string)
+	if !ok {
+		pre = ""
+	}
+
+	return fmt.Sprintf("%s%s", pre, format)
 }
 
 // Info logs to the INFO log.
@@ -37,7 +50,7 @@ func (g *Glogger) Infoln(args ...interface{}) {
 // Infof logs to the INFO log.
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func (g *Glogger) Infof(format string, args ...interface{}) {
-	Infof(format, setPrefix(g, args)...)
+	Infof(setPrefixf(g, format), args...)
 }
 
 // Warning logs to the WARNING and INFO logs.
@@ -61,7 +74,7 @@ func (g *Glogger) Warningln(args ...interface{}) {
 // Warningf logs to the WARNING and INFO logs.
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func (g *Glogger) Warningf(format string, args ...interface{}) {
-	Warningf(format, setPrefix(g, args)...)
+	Warningf(setPrefixf(g, format), args...)
 }
 
 // Error logs to the ERROR, WARNING, and INFO logs.
@@ -85,10 +98,10 @@ func (g *Glogger) Errorln(args ...interface{}) {
 // Errorf logs to the ERROR, WARNING, and INFO logs.
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func (g *Glogger) Errorf(format string, args ...interface{}) {
-	Errorf(format, setPrefix(g, args)...)
+	Errorf(setPrefixf(g, format), args...)
 }
 
-// Fatag logs to the FATAg, ERROR, WARNING, and INFO logs,
+// Fatal logs to the FATAg, ERROR, WARNING, and INFO logs,
 // including a stack trace of alg running goroutines, then calls os.Exit(255).
 // Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
 func (g *Glogger) Fatal(args ...interface{}) {
@@ -112,7 +125,7 @@ func (g *Glogger) Fatalln(args ...interface{}) {
 // including a stack trace of alg running goroutines, then calls os.Exit(255).
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func (g *Glogger) Fatalf(format string, args ...interface{}) {
-	Fatalf(format, setPrefix(g, args)...)
+	Fatalf(setPrefixf(g, format), args...)
 }
 
 // Exit logs to the FATAg, ERROR, WARNING, and INFO logs, then calls os.Exit(1).
@@ -135,5 +148,5 @@ func (g *Glogger) Exitln(args ...interface{}) {
 // Exitf logs to the FATAg, ERROR, WARNING, and INFO logs, then calls os.Exit(1).
 // Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
 func (g *Glogger) Exitf(format string, args ...interface{}) {
-	Exitf(format, setPrefix(g, args)...)
+	Exitf(setPrefixf(g, format), args...)
 }

--- a/glogger.go
+++ b/glogger.go
@@ -1,0 +1,139 @@
+// Glogger contains a copy of the exported glog logging functions but
+// it turns them into methods and allows adding prefixes to the logs.
+// This allows you "namespacing" the printout with something such as
+// the name of the function where that triggered it.
+
+// Eventually Glogger can be expanded to do more than simply add a prefix
+
+package glog
+
+// Glogger provides a prefix to log args
+type Glogger struct {
+	Prefix interface{}
+}
+
+func setPrefix(g *Glogger, args []interface{}) []interface{} {
+	return append([]interface{}{g.Prefix}, args...)
+}
+
+// Info logs to the INFO log.
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func (g *Glogger) Info(args ...interface{}) {
+	Info(setPrefix(g, args)...)
+}
+
+// InfoDepth acts as Info but uses depth to determine which calg frame to log.
+// InfoDepth(0, "msg") is the same as Info("msg").
+func (g *Glogger) InfoDepth(depth int, args ...interface{}) {
+	InfoDepth(depth, setPrefix(g, args)...)
+}
+
+// Infoln logs to the INFO log.
+// Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
+func (g *Glogger) Infoln(args ...interface{}) {
+	Infoln(setPrefix(g, args)...)
+}
+
+// Infof logs to the INFO log.
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func (g *Glogger) Infof(format string, args ...interface{}) {
+	Infof(format, setPrefix(g, args)...)
+}
+
+// Warning logs to the WARNING and INFO logs.
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func (g *Glogger) Warning(args ...interface{}) {
+	Warning(setPrefix(g, args)...)
+}
+
+// WarningDepth acts as Warning but uses depth to determine which calg frame to log.
+// WarningDepth(0, "msg") is the same as Warning("msg").
+func (g *Glogger) WarningDepth(depth int, args ...interface{}) {
+	WarningDepth(depth, setPrefix(g, args)...)
+}
+
+// Warningln logs to the WARNING and INFO logs.
+// Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
+func (g *Glogger) Warningln(args ...interface{}) {
+	Warningln(setPrefix(g, args)...)
+}
+
+// Warningf logs to the WARNING and INFO logs.
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func (g *Glogger) Warningf(format string, args ...interface{}) {
+	Warningf(format, setPrefix(g, args)...)
+}
+
+// Error logs to the ERROR, WARNING, and INFO logs.
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func (g *Glogger) Error(args ...interface{}) {
+	Error(setPrefix(g, args)...)
+}
+
+// ErrorDepth acts as Error but uses depth to determine which calg frame to log.
+// ErrorDepth(0, "msg") is the same as Error("msg").
+func (g *Glogger) ErrorDepth(depth int, args ...interface{}) {
+	ErrorDepth(depth, setPrefix(g, args)...)
+}
+
+// Errorln logs to the ERROR, WARNING, and INFO logs.
+// Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
+func (g *Glogger) Errorln(args ...interface{}) {
+	Errorln(setPrefix(g, args)...)
+}
+
+// Errorf logs to the ERROR, WARNING, and INFO logs.
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func (g *Glogger) Errorf(format string, args ...interface{}) {
+	Errorf(format, setPrefix(g, args)...)
+}
+
+// Fatag logs to the FATAg, ERROR, WARNING, and INFO logs,
+// including a stack trace of alg running goroutines, then calls os.Exit(255).
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func (g *Glogger) Fatal(args ...interface{}) {
+	Fatal(setPrefix(g, args)...)
+}
+
+// FatalDepth acts as Fatag but uses depth to determine which calg frame to log.
+// FatalDepth(0, "msg") is the same as Fatal("msg").
+func (g *Glogger) FatalDepth(depth int, args ...interface{}) {
+	FatalDepth(depth, setPrefix(g, args)...)
+}
+
+// Fatalln logs to the FATAg, ERROR, WARNING, and INFO logs,
+// including a stack trace of alg running goroutines, then calls os.Exit(255).
+// Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
+func (g *Glogger) Fatalln(args ...interface{}) {
+	Fatalln(setPrefix(g, args)...)
+}
+
+// Fatalf logs to the FATAg, ERROR, WARNING, and INFO logs,
+// including a stack trace of alg running goroutines, then calls os.Exit(255).
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func (g *Glogger) Fatalf(format string, args ...interface{}) {
+	Fatalf(format, setPrefix(g, args)...)
+}
+
+// Exit logs to the FATAg, ERROR, WARNING, and INFO logs, then calls os.Exit(1).
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func (g *Glogger) Exit(args ...interface{}) {
+	Exit(setPrefix(g, args)...)
+}
+
+// ExitDepth acts as Exit but uses depth to determine which calg frame to log.
+// ExitDepth(0, "msg") is the same as Exit("msg").
+func (g *Glogger) ExitDepth(depth int, args ...interface{}) {
+	ExitDepth(depth, setPrefix(g, args)...)
+}
+
+// Exitln logs to the FATAg, ERROR, WARNING, and INFO logs, then calls os.Exit(1).
+func (g *Glogger) Exitln(args ...interface{}) {
+	Exitln(setPrefix(g, args)...)
+}
+
+// Exitf logs to the FATAg, ERROR, WARNING, and INFO logs, then calls os.Exit(1).
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func (g *Glogger) Exitf(format string, args ...interface{}) {
+	Exitf(format, setPrefix(g, args)...)
+}

--- a/glogger_test.go
+++ b/glogger_test.go
@@ -23,3 +23,22 @@ func TestSetPrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestSetPrefixf(t *testing.T) {
+	g := &Glogger{Prefix: "zero "}
+	expected := "zero one two"
+	og := "one two"
+	withPre := setPrefixf(g, og)
+
+	if withPre != expected {
+		t.Errorf("Resulting string did not match expected: %q != %q", withPre, expected)
+	}
+
+	// Should fail to add prefix
+	g.Prefix = 0
+	withPre = setPrefixf(g, og)
+
+	if withPre != og {
+		t.Errorf("Resulting string was expected to be unchanged (%q). Intead we got: %q", og, withPre)
+	}
+}

--- a/glogger_test.go
+++ b/glogger_test.go
@@ -1,0 +1,25 @@
+package glog
+
+import (
+	"testing"
+)
+
+const (
+	zero int = iota
+	one
+)
+const two = "two"
+
+func TestSetPrefix(t *testing.T) {
+	g := &Glogger{Prefix: zero}
+	expected := []interface{}{zero, one, two}
+
+	x := []interface{}{one, two}
+	y := setPrefix(g, x)
+
+	for i, v := range y {
+		if v != expected[i] {
+			t.Errorf("Resulting slice did not match expected: %q != %q at index %d", v, expected[i], i)
+		}
+	}
+}


### PR DESCRIPTION
Glogger contains a copy of the exported glog logging functions but it turns them into methods and allows adding prefixes to the logs. This allows "namespacing" the printout with something such as the name of the function that triggered it.