### PR TITLE
Allow the user to prefix our flags' names

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -395,13 +395,25 @@ type flushSyncWriter interface {
 	io.Writer
 }
 
+// Allow the user to set this variable at build-time, to prefix our flags'
+// names with something of their choice.
+var FlagPrefix string
+
+func prefix(s string) string {
+	if FlagPrefix != "" {
+		return FlagPrefix + s
+	}
+
+	return s
+}
+
 func init() {
-	flag.BoolVar(&logging.toStderr, "logtostderr", false, "log to standard error instead of files")
-	flag.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
-	flag.Var(&logging.verbosity, "v", "log level for V logs")
-	flag.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
-	flag.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
-	flag.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
+	flag.BoolVar(&logging.toStderr, prefix("logtostderr"), false, "log to standard error instead of files")
+	flag.BoolVar(&logging.alsoToStderr, prefix("alsologtostderr"), false, "log to standard error as well as files")
+	flag.Var(&logging.verbosity, prefix("v"), "log level for V logs")
+	flag.Var(&logging.stderrThreshold, prefix("stderrthreshold"), "logs at or above this threshold go to stderr")
+	flag.Var(&logging.vmodule, prefix("vmodule"), "comma-separated list of pattern=N settings for file-filtered logging")
+	flag.Var(&logging.traceLocation, prefix("log_backtrace_at"), "when logging hits line file:N, emit a stack trace")
 
 	// Default stderrThreshold is ERROR.
 	logging.stderrThreshold = errorLog

--- a/glog_file.go
+++ b/glog_file.go
@@ -38,7 +38,7 @@ var logDirs []string
 
 // If non-empty, overrides the choice of directory in which to write logs.
 // See createLogDirs for the full list of possible destinations.
-var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
+var logDir = flag.String(prefix("log_dir"), "", "If non-empty, write log files in this directory")
 
 func createLogDirs() {
 	if *logDir != "" {


### PR DESCRIPTION
This problem has been reported quite a few times over the years; for
example, see it reported at golang-nuts mailing list [1], and cue lang
issue [2].

[1]: https://groups.google.com/g/golang-nuts/c/vj8ozVqemnQ
[2]: https://github.com/cue-lang/cue/issues/1199

The problem is that, that glog package registers some flags in its
init() function. The list of registered flags also includes the `-v`
flag, which is usually used by developers either to control verbosity of
their code-execution, or to show the software version. It's notable that
all the complaints are regarding the `-v` flag, and none about the other
flags, since those other flags are unlikely be used by any other
developer.

The proposed fix allows the user of the glog package to change/prefix
glog's flags' names, so that they will not conflict with any flags that
they want to use.

This approach to the problem has a few advantages, compared to other
options like, disabling all the flags in glog.

1. The default behaviour of the glog library is unchanged. So the
current users of the library will not be affected.

2. Any new users who wish to use the -v, or other glog-occupied flag,
can do so at build time.

3. The new users can still use the glog features/flags, albeit with a
prefix.

4. We are not enforcing some specific prefix, which may also conflict.

5. The --help flag, correctly reports the changed/prefixed flag names.

```
$ ./main --help
Usage of ./main:

  ... other glog: prefixed flags ...

  -glog:v value
        log level for V logs
  -glog:vmodule value
        comma-separated list of pattern=N settings for file-filtered logging
  -v value
        Emit verbose execution progress

```

Please also see sample code [3] that demonstrates the problem, and how
the patch fixes the problem.

[3]: https://github.com/gurjeet/glog_fix_test
