### PR TITLE
Windows: Support Nano Server

### DIFF
--- a/glog_file.go
+++ b/glog_file.go
@@ -60,9 +60,15 @@ func init() {
 		host = shortHostname(h)
 	}
 
-	current, err := user.Current()
-	if err == nil {
-		userName = current.Username
+	// NetApi32.dll does not exists in Nano Server
+	// https://github.com/golang/go/issues/21867
+	if _, err := os.Stat(os.Getenv("windir") + `\System32\netapi32.dll`); errors.Is(err, os.ErrNotExist) {
+		userName = os.Getenv("USERDOMAIN") + `\` + os.Getenv("USERNAME")
+	} else {
+		current, err := user.Current()
+		if err == nil {
+			userName = current.Username
+		}
 	}
 
 	// Sanitize userName since it may contain filepath separators on Windows.


### PR DESCRIPTION
Microsoft employees have been working hard to trying get Windows containers to small like Linux containers are and nowadays many Go applications can already run on Nano Server containers.

However many applications which are originally build for Linux and later ported to Windows do use glog which breaks Nano Server compatibility just because of way how username is queried from Windows.

Correct place to fix this issue probably would be Go it selves https://github.com/golang/go/issues/21867 but because it looks be that it does not happen I open this PR here with hope that this simple workaround can be included to here instead of.

On theory this same method might works even all the Windows versions but because it is quite tricky to verify I made this on way that it only apply to Nano Server where `NetApi32.dll` does not exists.