### PR TITLE
glog: use os.Stderr directly for writing to stderr

### DIFF
--- a/glog_file.go
+++ b/glog_file.go
@@ -153,8 +153,6 @@ var sinks struct {
 }
 
 func init() {
-	sinks.stderr.w = os.Stderr
-
 	// Register stderr first: that way if we crash during file-writing at least
 	// the log will have gone somewhere.
 	logsink.TextSinks = append(logsink.TextSinks, &sinks.stderr, &sinks.file)
@@ -167,7 +165,7 @@ func init() {
 // if they meet certain conditions.
 type stderrSink struct {
 	mu sync.Mutex
-	w  io.Writer
+	w  io.Writer // if nil Emit uses os.Stderr directly
 }
 
 // Enabled implements logsink.Text.Enabled.  It returns true if any of the
@@ -182,8 +180,11 @@ func (s *stderrSink) Enabled(m *logsink.Meta) bool {
 func (s *stderrSink) Emit(m *logsink.Meta, data []byte) (n int, err error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	dn, err := s.w.Write(data)
+	w := s.w
+	if w == nil {
+		w = os.Stderr
+	}
+	dn, err := w.Write(data)
 	n += dn
 	return n, err
 }


### PR DESCRIPTION
This was raised in https://groups.google.com/g/golang-nuts/c/o85vycfiGVY/m/MblpnfF6BQAJ.

Before the 1.1.0 release it was possible to set os.Stderr to a different *os.File (like an os.Pipe) to capture output that is written to stderr. Restore that behavior.