### PR TITLE
glog: Use Fatalf to exit when writing to logsinks fails

### DIFF
--- a/glog.go
+++ b/glog.go
@@ -247,10 +247,7 @@ func sinkf(meta *logsink.Meta, format string, args ...any) {
 	}
 
 	if err != nil {
-		meta.Severity = logsinc.Fatal
-		logsink.Printf(meta, "glog: exiting because of error: %s", err)
-		sinks.file.Flush()
-		os.Exit(2)
+		Fatalf("glog: exiting because of error writing previous log to sinks: %v", err)
 	}
 }
 

--- a/glog.go
+++ b/glog.go
@@ -247,6 +247,7 @@ func sinkf(meta *logsink.Meta, format string, args ...any) {
 	}
 
 	if err != nil {
+		meta.Severity = logsinc.Fatal
 		logsink.Printf(meta, "glog: exiting because of error: %s", err)
 		sinks.file.Flush()
 		os.Exit(2)


### PR DESCRIPTION
Without this, our program exited without any message when there are some disk write error (e.g. no space left on device).

By increasing the severity, we can notice what caused the program exited as the log will be shown on stderr.

This is imported from http://cl/748177961